### PR TITLE
Fix spaces between keywords in gifwit library

### DIFF
--- a/library.gifwit
+++ b/library.gifwit
@@ -20,7 +20,7 @@
     {% assign path = image.path | uri_escape %}
     {
       "url": "{{ site.github.url | append: "/" | append: path | json }}",
-      "keywords": "{% for part in parts %}{{ part }}{% unless forloop.last %} {% endunless %}{% endfor %}"
+      "keywords": "{{ parts | join:delimiter | json }}"
     }{% unless forloop.last %},{% endunless %}
   {% endfor %}
   ]


### PR DESCRIPTION
Without this, the `library.gifwit` file produces keywords that look like `"keywords": "amazedhepburnoffsunglasses"`, instead of `"keywords": "amazed hepburn off sunglasses"`. I'm guessing this has to do with the nested for loops. In any case, this is a bit more concise.