### PR TITLE
Improve file generation, add type-to-filter bar to site

### DIFF
--- a/_layouts/home.html
+++ b/_layouts/home.html
@@ -7,27 +7,148 @@
 
   <header class="page-header">
     <div class="img-preview">
-      <img src="excited/aha.gif" alt="" class="banner-img">
+      <img src="excited/aha.gif" id="preview-background" alt="" class="banner-img">
       <img src="" id="preview" class="gif-preview">
     </div>
+    <div class="filter">
+      <input type="text" id="filter-input" placeholder="Type to filter..." />
+    </div>
+
     {{ content }}
   </header>
 
-  <div class="gif-listing">
-  {% include site-index.html %}
+  <div id="gif-listing" class="gif-listing">
   </div>
 
   <script type="text/javascript">
-    var preview = document.getElementById("preview");
+    var preview = document.getElementById('preview'),
+      previewBackground = document.getElementById('preview-background'),
+      filterInput = document.getElementById('filter-input'),
+      gifList = document.getElementById('gif-listing'),
+      data = {% include site-index.json %};
+
+    function togglePreviewBackground() {
+      if (preview.src) {
+        previewBackground.style.display = 'none';
+      } else {
+        previewBackground.style.display = '';
+      }
+    }
 
     function hoverListener(evt) {
       preview.src = evt.target.href;
+
+      togglePreviewBackground();
     };
 
-    var links = document.getElementsByClassName("gif");
-    for(var i=0; i<links.length; i++) {
-      links[i].addEventListener("mouseover", hoverListener);
+    function clickListener(evt) {
+      // Block clicking on mobile
+      if (!(evt.metaKey || evt.ctlKey || evt.altKey)) {
+        evt.preventDefault();
+
+        preview.src = evt.target.href;
+
+        togglePreviewBackground();
+      }
     }
+
+    function createCategoryListNode(ulNode, name) {
+      var liNode = document.createElement('li'),
+        categoryULNode = document.createElement('ul');
+
+      liNode.setAttribute('class', 'category-group');
+      liNode.setAttribute('data-title', name);
+      liNode.innerHTML = name;
+      liNode.appendChild(categoryULNode);
+
+      ulNode.appendChild(liNode);
+
+      return categoryULNode;
+    }
+
+    var lastCategory = data[0].category,
+      ulNode = document.createElement('ul'),
+      currentCategoryListNode = createCategoryListNode(ulNode, lastCategory);
+
+    for (var i = 0; i < data.length; i++) {
+      // Create the dom elements for each item
+      var item = data[i],
+        liNode = document.createElement('li'),
+        aNode = document.createElement('a');
+
+      if (item.category !== lastCategory) {
+        lastCategory = item.category;
+        currentCategoryListNode = createCategoryListNode(ulNode, item.category);
+      }
+
+      aNode.setAttribute('href', '{{ site.github.url | append: "/" }}' + item.path);
+      aNode.setAttribute('title', item.title);
+      aNode.setAttribute('class', 'gif');
+      aNode.innerHTML = item.title;
+
+      liNode.appendChild(aNode);
+      currentCategoryListNode.appendChild(liNode);
+    }
+
+    gifList.appendChild(ulNode);
+
+    currentCategoryListNode = undefined;
+    ulNode = undefined;
+
+    var links = document.getElementsByClassName("gif");
+    for (var i = 0; i < links.length; i++) {
+      links[i].addEventListener("mouseover", hoverListener);
+      links[i].addEventListener("click", clickListener);
+    }
+
+    function filterResultsFromInputListener (evt) {
+      var filterStrings = evt.target.value.toLowerCase().replace(/[^a-z0-9 ]+/g, '').split(' '),
+        visibleCategories = [];
+
+      for (var i = 0; i < links.length; i++) {
+        var element = links[i].parentNode,
+          elementData = data[i],
+          visible = true;
+
+        if (filterStrings.length > 0) {
+          // See if this element matches our filter
+          var elementTags = elementData.tags.join(' ');
+          for (var j = 0; j < filterStrings.length; j++) {
+            visible = elementTags.indexOf(filterStrings[j]) !== -1;
+          }
+        }
+
+        if (visible) {
+          if (visibleCategories.length === 0) {
+            // No need to search, add the category
+            visibleCategories.push(elementData.category);
+          } else if (visibleCategories[0] !== elementData.category) {
+            // We push the category onto the front of the array. And the data is always sorted by category
+            visibleCategories.unshift(elementData.category);
+          }
+
+          element.classList.remove('hidden');
+        } else {
+          element.classList.add('hidden');
+        }
+      }
+
+      // Hide all the categories that aren't in the list
+      var categoryNodes = document.getElementsByClassName("category-group");
+      for (var i = 0; i < categoryNodes.length; i++) {
+        var categoryNode = categoryNodes[i],
+          categoryTitle = categoryNode.getAttribute('data-title');
+        if (visibleCategories.indexOf(categoryTitle) !== -1) {
+          // Show the category
+          categoryNode.classList.remove('hidden');
+        } else {
+          categoryNode.classList.add('hidden');
+        }
+      }
+    }
+
+    filterInput.addEventListener('keyup', filterResultsFromInputListener);
+    filterInput.addEventListener('change', filterResultsFromInputListener);
   </script>
 
 </body>

--- a/css/main.scss
+++ b/css/main.scss
@@ -85,6 +85,19 @@ body{
     @media (max-width: 400px) { height: 200px; }
   }
 
+  .filter {
+    width: 100%;
+    height: 30px;
+    position: relative;
+    z-index: 1;
+    overflow: hidden;
+
+    input {
+      width: 100%;
+      height: 30px;
+    }
+  }
+
   .banner-img {
     width: 100%;
     z-index: 1;
@@ -153,6 +166,11 @@ body{
       column-break-inside: avoid;
       color: $green;
 
+      &.hidden {
+        display: none;
+        margin: 0;
+      }
+
       // Style the sub-list of gifs
       > ul {
         padding: 5px 0 0;
@@ -171,6 +189,11 @@ body{
           border-radius: 5px;
           padding: 0;
           margin: 0 0 5px 0;
+
+          &.hidden {
+            display: none;
+            margin: 0;
+          }
 
           // Style individual gif links
           a {

--- a/index.md
+++ b/index.md
@@ -6,4 +6,4 @@ layout: home
 
 <p>Oh Hai! You've found my Gif collection. <br>Fork me on GitHub at <a href="{{ site.github.repository_url }}" title="Revision {{ site.github.build_revision }}">{{ site.github.repository_nwo }}</a> <br> (Hover to preview an image)</p>
 
-<p>Import into Gifwit with my <a href="library.gifwit">library</a>.</p>
+<p>Import into <a href="http://gifwit.com/">Gifwit</a> with my <a href="library.gifwit">library</a>.</p>

--- a/index.md
+++ b/index.md
@@ -1,4 +1,5 @@
 ---
+title: Gif Collection
 layout: home
 ---
 

--- a/library.gifwit
+++ b/library.gifwit
@@ -6,21 +6,10 @@
   "images": [
   {% assign delimiter = ' ' %}
   {% for image in site.data.static_files %}
-    {% assign parts_str = '' %}{% assign parts = image.path | split:'/' %}
-    {% for part in parts %}
-      {% assign keywords = part | replace:image.extname, '' | downcase | replace:'-', delimiter | replace:'_', delimiter | split:delimiter %}
-      {% for k in keywords %}
-        {% assign parts_arr = parts_str | split:delimiter %}
-        {% unless parts_arr contains k %}
-          {% assign parts_str = parts_str | append:delimiter | append:k %}
-        {% endunless %}
-      {% endfor %}
-    {% endfor %}
-    {% assign parts = parts_str | remove_first:delimiter | split:delimiter | sort %}
     {% assign path = image.path | uri_escape %}
     {
       "url": "{{ site.github.url | append: "/" | append: path | json }}",
-      "keywords": "{{ parts | join:delimiter | json }}"
+      "keywords": "{{ image.tags | join: ' ' | json }}"
     }{% unless forloop.last %},{% endunless %}
   {% endfor %}
   ]

--- a/script/build_site_index
+++ b/script/build_site_index
@@ -1,11 +1,11 @@
 #! /usr/bin/env ruby
 
-require 'builder'
 require 'fileutils'
+require 'json'
 require 'yaml'
 
 def dir_blacklist
-  ["css", "sass", "script"]
+  ["css", "js", "images", "script"]
 end
 
 def useless?(f)
@@ -20,42 +20,33 @@ def get_gif_dirs
 end
 
 def liquid_info_for_file(path)
+  # Get all the tags from the path, but without the extension
+  tags = path.gsub('-', File::SEPARATOR).gsub('_', File::SEPARATOR).gsub('.', File::SEPARATOR).split(File::SEPARATOR)[0 .. -1]
+  tags.uniq!
+  tags.sort!
+
   {
+    "title"         => File.basename(path),
+    "category"      => path.split(File::SEPARATOR)[0],
     "path"          => path,
     "modified_time" => File.mtime(path).to_i,
-    "extname"       => File.extname(path)
+    "tags"          => tags
   }
 end
-
-list = Builder::XmlMarkup.new(
-  target: File.open("_includes/site-index.html", 'w'),
-  indent: 0,
-  margin: 0
-)
 
 dirs  = get_gif_dirs
 files = []
 
-list.ul do |builder|
-  dirs.each do |dir|
-    builder.li do |dir_element|
-      dir_element.text!(dir)
-      dir_element.ul do |ul|
-        Dir.glob("#{dir}/**/*.{gif,jpg,jpeg,png}") do |gif|
-          files << liquid_info_for_file(gif)
-          ul.li do |li|
-            li.a(
-              File.basename(gif),
-              "href"  => gif,
-              "title" => gif,
-              "class" => "gif"
-            )
-          end
-        end
-      end
-    end
+dirs.each do |dir|
+  Dir.glob("#{dir}/**/*.{gif,jpg,jpeg,png}") do |gif|
+    files << liquid_info_for_file(gif)
   end
 end
 
+# Sort the files
+files.sort! { |a,b| a[:path] <=> b[:path] }
+
 FileUtils.mkdir_p("_data") unless File.directory?("_data")
+FileUtils.mkdir_p("_includes") unless File.directory?("_includes")
 File.open("_data/static_files.yml", 'w') { |f| f.write(YAML.dump(files)) }
+File.open("_includes/site-index.json", 'w') { |f| f.write(JSON.dump(files)) }


### PR DESCRIPTION
I moved a bunch of the logic to the `build_site_index` script, and then embedded the properties in the `static_files.yml` and a new file, `site-index.json` (`site-index.json` isn't checked in since your gifs are different than mine).

The `site-index.json` is now included by the home template, and renders all the gifs using vanilla Javascript. This allows one to easily do filtering on the list of gifs with javascript.

You can see it in action here http://gifs.chrisstreeter.com/